### PR TITLE
feat: Select menu by keyboard

### DIFF
--- a/src/graphics/WindowManager.java
+++ b/src/graphics/WindowManager.java
@@ -1,9 +1,8 @@
 package graphics;
 
 import java.awt.CardLayout;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -17,10 +16,8 @@ import graphics.screens.SettingMenuScreen;
 public class WindowManager {
     private static WindowManager mUniqueInstance = null;
 
-    public JFrame mWindow;
-    public CardLayout mCards;
-
-    static final String BAR = new String("Bar");
+    private static JFrame mWindow;
+    private static CardLayout mCards;
 
     private WindowManager() {
         SettingInfoDesc mSettingInfoDesc = SettingInfoDesc.getInstance();
@@ -37,41 +34,9 @@ public class WindowManager {
 
         mWindow.getContentPane().add("main", new MainMenuScreen());
         mWindow.getContentPane().add("game", GameScreen.getInstance());
-        mWindow.getContentPane().add("setting", new SettingMenuScreen());
         mWindow.getContentPane().add("score", new ScoreBoardScreen());
+        mWindow.getContentPane().add("setting", new SettingMenuScreen());
 
-        //
-        // Define action when keybaord message occurs
-        //
-        mWindow.addKeyListener(new KeyListener() {
-            @Override
-            public void keyPressed(KeyEvent e) {
-                switch (e.getKeyCode()) {
-                    case KeyEvent.VK_Q:
-                        mCards.show(mWindow.getContentPane(), "main");
-                        break;
-                    case KeyEvent.VK_W:
-                        mCards.show(mWindow.getContentPane(), "game");
-                        break;
-                    case KeyEvent.VK_E:
-                        mCards.show(mWindow.getContentPane(), "setting");
-                        break;
-                    case KeyEvent.VK_R:
-                        mCards.show(mWindow.getContentPane(), "score");
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            @Override
-            public void keyReleased(KeyEvent e) {
-            }
-
-            @Override
-            public void keyTyped(KeyEvent e) {
-            }
-        });
         mWindow.setFocusable(true);
 
         //
@@ -79,7 +44,7 @@ public class WindowManager {
         //
         mWindow.addWindowListener(new WindowAdapter() {
             @Override
-            public void windowClosing(java.awt.event.WindowEvent windowEvent) {
+            public void windowClosing(WindowEvent windowEvent) {
                 if (JOptionPane.showConfirmDialog(mWindow,
                         "Are you sure you want to close this window?", "Close Window?",
                         JOptionPane.YES_NO_OPTION,
@@ -99,7 +64,7 @@ public class WindowManager {
         return mUniqueInstance;
     }
 
-    public void show(String name) {
+    public static void show(String name) {
         // TODO: Catch wrong name exception and assert
         mCards.show(mWindow.getContentPane(), name);
     }

--- a/src/graphics/WindowManager.java
+++ b/src/graphics/WindowManager.java
@@ -64,7 +64,7 @@ public class WindowManager {
         return mUniqueInstance;
     }
 
-    public static void show(String name) {
+    public void show(String name) {
         // TODO: Catch wrong name exception and assert
         mCards.show(mWindow.getContentPane(), name);
     }

--- a/src/graphics/WindowManager.java
+++ b/src/graphics/WindowManager.java
@@ -32,7 +32,7 @@ public class WindowManager {
 
         mWindow.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-        mWindow.getContentPane().add("main", new MainMenuScreen());
+        mWindow.getContentPane().add("main", MainMenuScreen.getInstance());
         mWindow.getContentPane().add("game", GameScreen.getInstance());
         mWindow.getContentPane().add("score", new ScoreBoardScreen());
         mWindow.getContentPane().add("setting", new SettingMenuScreen());

--- a/src/graphics/screens/MainMenuScreen.java
+++ b/src/graphics/screens/MainMenuScreen.java
@@ -1,11 +1,19 @@
 package graphics.screens;
 
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
 import graphics.WindowManager;
-
-import java.awt.*;
-import java.awt.event.*;
-
-import javax.swing.*;
 
 public class MainMenuScreen extends JPanel {
     private static MainMenuScreen uniqueInstance = null;
@@ -16,7 +24,7 @@ public class MainMenuScreen extends JPanel {
         JLabel title = new JLabel("Main");
 
         menuButton = new JButton[4];
-        String[] buttonText = new String[]{"Start", "Show scoreboard", "Setting", "Exit"};
+        String[] buttonText = new String[] { "Start", "Show scoreboard", "Setting", "Exit" };
 
         this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         this.setBackground(Color.gray);
@@ -29,13 +37,13 @@ public class MainMenuScreen extends JPanel {
 
             switch (buttonIndex) {
                 case 0:
-                    menuButton[buttonIndex].addActionListener(e -> WindowManager.show("game"));
+                    menuButton[buttonIndex].addActionListener(e -> WindowManager.getInstance().show("game"));
                     break;
                 case 1:
-                    menuButton[buttonIndex].addActionListener(e -> WindowManager.show("score"));
+                    menuButton[buttonIndex].addActionListener(e -> WindowManager.getInstance().show("score"));
                     break;
                 case 2:
-                    menuButton[buttonIndex].addActionListener(e -> WindowManager.show("setting"));
+                    menuButton[buttonIndex].addActionListener(e -> WindowManager.getInstance().show("setting"));
                     break;
                 case 3:
                     menuButton[buttonIndex].addActionListener(new ActionListener() {
@@ -68,10 +76,12 @@ public class MainMenuScreen extends JPanel {
                     super.keyPressed(e);
                     switch (e.getKeyCode()) {
                         case KeyEvent.VK_UP:
-                            if (buttonIndex > 0) menuButton[buttonIndex - 1].requestFocus();
+                            if (buttonIndex > 0)
+                                menuButton[buttonIndex - 1].requestFocus();
                             break;
                         case KeyEvent.VK_DOWN:
-                            if (buttonIndex < menuButton.length - 1) menuButton[buttonIndex + 1].requestFocus();
+                            if (buttonIndex < menuButton.length - 1)
+                                menuButton[buttonIndex + 1].requestFocus();
                             break;
                     }
                 }

--- a/src/graphics/screens/MainMenuScreen.java
+++ b/src/graphics/screens/MainMenuScreen.java
@@ -4,17 +4,15 @@ import graphics.WindowManager;
 
 import java.awt.*;
 import java.awt.event.*;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 
 import javax.swing.*;
 
 public class MainMenuScreen extends JPanel {
-    private JPanel buttonGroup;
-    private JButton[] menuButton;
+    private static MainMenuScreen uniqueInstance = null;
+    private final JButton[] menuButton;
 
     public MainMenuScreen() {
-        buttonGroup = new JPanel();
+        JPanel buttonGroup = new JPanel();
         JLabel title = new JLabel("Main");
 
         menuButton = new JButton[4];
@@ -83,11 +81,22 @@ public class MainMenuScreen extends JPanel {
         this.add(buttonGroup);
     }
 
+    public static MainMenuScreen getInstance() {
+        if (uniqueInstance == null) {
+            uniqueInstance = new MainMenuScreen();
+        }
+        return uniqueInstance;
+    }
 
-//    private int getJButtonIndex(final Component component) {
-//        for (int i = 0; i < ButtonGroup.getComponentCount(); i++) {
-//            if (ButtonGroup.getComponent(i).equals(component)) return i;
-//        }
-//        return -1;
-//    }
+    public void setKeyListener(KeyListener kl) {
+        super.addKeyListener(kl);
+        super.setFocusable(true);
+        super.requestFocus();
+    }
+
+    public void unsetKeyListener() {
+        for (int i = 0; i < menuButton.length; i++)
+            menuButton[i].setFocusable(false);
+        super.setFocusable(false);
+    }
 }

--- a/src/graphics/screens/MainMenuScreen.java
+++ b/src/graphics/screens/MainMenuScreen.java
@@ -1,16 +1,93 @@
 package graphics.screens;
 
-import java.awt.Color;
+import graphics.WindowManager;
 
-import javax.swing.JLabel;
-import javax.swing.JPanel;
+import java.awt.*;
+import java.awt.event.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.*;
 
 public class MainMenuScreen extends JPanel {
-    private JLabel mTemp;
+    private JPanel buttonGroup;
+    private JButton[] menuButton;
 
     public MainMenuScreen() {
-        mTemp = new JLabel("Main");
-        super.setBackground(Color.gray);
-        super.add(mTemp);
+        buttonGroup = new JPanel();
+        JLabel title = new JLabel("Main");
+
+        menuButton = new JButton[4];
+        String[] buttonText = new String[]{"Start", "Show scoreboard", "Setting", "Exit"};
+
+        this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.setBackground(Color.gray);
+        this.add(title);
+        this.setFocusable(true);
+
+        for (int i = 0; i < menuButton.length; i++) {
+            final int buttonIndex = i;
+            menuButton[buttonIndex] = new JButton(buttonText[buttonIndex]);
+
+            switch (buttonIndex) {
+                case 0:
+                    menuButton[buttonIndex].addActionListener(e -> WindowManager.show("game"));
+                    break;
+                case 1:
+                    menuButton[buttonIndex].addActionListener(e -> WindowManager.show("score"));
+                    break;
+                case 2:
+                    menuButton[buttonIndex].addActionListener(e -> WindowManager.show("setting"));
+                    break;
+                case 3:
+                    menuButton[buttonIndex].addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            if (JOptionPane.showConfirmDialog(MainMenuScreen.this,
+                                    "Are you sure you want to close this window?",
+                                    "Close Window?", JOptionPane.YES_NO_OPTION,
+                                    JOptionPane.QUESTION_MESSAGE) == JOptionPane.YES_OPTION) {
+                                System.exit(0);
+                            }
+                        }
+                    });
+                    System.out.println("exit button clicked");
+                    break;
+            }
+            KeyListener onClickEnter = new KeyAdapter() {
+                @Override
+                public void keyPressed(KeyEvent e) {
+                    super.keyPressed(e);
+                    if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+                        ((JButton) e.getComponent()).doClick();
+                    }
+                }
+            };
+            menuButton[buttonIndex].addKeyListener(onClickEnter);
+            menuButton[buttonIndex].addKeyListener(new KeyAdapter() {
+                @Override
+                public void keyPressed(KeyEvent e) {
+                    super.keyPressed(e);
+                    switch (e.getKeyCode()) {
+                        case KeyEvent.VK_UP:
+                            if (buttonIndex > 0) menuButton[buttonIndex - 1].requestFocus();
+                            break;
+                        case KeyEvent.VK_DOWN:
+                            if (buttonIndex < menuButton.length - 1) menuButton[buttonIndex + 1].requestFocus();
+                            break;
+                    }
+                }
+            });
+            buttonGroup.add(menuButton[buttonIndex]);
+        }
+        this.add(buttonGroup);
     }
+
+
+//    private int getJButtonIndex(final Component component) {
+//        for (int i = 0; i < ButtonGroup.getComponentCount(); i++) {
+//            if (ButtonGroup.getComponent(i).equals(component)) return i;
+//        }
+//        return -1;
+//    }
 }

--- a/src/graphics/screens/MainMenuScreen.java
+++ b/src/graphics/screens/MainMenuScreen.java
@@ -19,12 +19,12 @@ public class MainMenuScreen extends JPanel {
     private static MainMenuScreen uniqueInstance = null;
     private final JButton[] menuButton;
 
-    public MainMenuScreen() {
+    private MainMenuScreen() {
         JPanel buttonGroup = new JPanel();
         JLabel title = new JLabel("Main");
 
         menuButton = new JButton[4];
-        String[] buttonText = new String[] { "Start", "Show scoreboard", "Setting", "Exit" };
+        String[] buttonText = new String[]{"Start", "Show scoreboard", "Setting", "Exit"};
 
         this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         this.setBackground(Color.gray);


### PR DESCRIPTION
## Issue
#21 

## Feature
1. 메인 panel 에서 다른 panel로 이동
  - 상하 버튼 클릭시 메뉴 이동 가능
  - enter 클릭시 `onClickEnter` 메서드가 호출되어 클릭
2. 종료 버튼 클릭 시 종료할 것인지 뭍는 dialog가 뜨고 확인버튼을 누르면 종료
<img width="912" alt="스크린샷 2022-03-29 19 40 57" src="https://user-images.githubusercontent.com/33178048/160594062-a9be1b00-fd46-438b-a8bf-cb1574c4cb4d.png">

## New Issue
- [ ] 다른 패널로 이동하면 해당 패널에서 키보드 조작이 되지 않음.
- [ ] 처음 프로그램을 실행했을 때 버튼(예를 들어 시작버튼)에 focus가 되지 않음.
